### PR TITLE
express_dump.sql

### DIFF
--- a/sql/express_dump.sql
+++ b/sql/express_dump.sql
@@ -4,13 +4,13 @@ SELECT DISTINCT
 	e.etype,
 	e.protein_id,
 	e.number_value,
-	e.zscore,
-	e.conf,
+--	e.zscore,
+--	e.conf,
 	e.oid,
 	p.sym AS "psymb",
 	p.name AS "pname",
 	t.id AS "tid",
-	t.idgfam,
+	t.fam,
 	t.tdl
 FROM
 	expression e
@@ -22,8 +22,8 @@ JOIN
 	target t ON t2tc.target_id = t.id
 WHERE
 	e.etype IN ( 'HPM Protein', 'GTEx' )
-	AND t.idgfam IS NOT NULL
+	AND t.fam IS NOT NULL
 ORDER BY
-	e.tissue, e.zscore, t.idgfam
+	e.tissue, t.fam
 	;
 --


### PR DESCRIPTION
Line 7,8 removed as columns e.zscore and e.conf are removed from table expression. Edited line 13,25,27 t.idgfam is renamed as t.fam in table target..