### PR TITLE
ortholog_disease_counts.sql

### DIFF
--- a/sql/ortholog_disease_counts.sql
+++ b/sql/ortholog_disease_counts.sql
@@ -2,8 +2,8 @@
 SELECT COUNT(DISTINCT ogd.id) AS "ortholog_disease_count_total" FROM ortholog_disease ogd ;
 SELECT COUNT(DISTINCT ogd.did) AS "disease_count" FROM ortholog_disease ogd ;
 SELECT COUNT(DISTINCT ogd.ortholog_id) AS "ortholog_count" FROM ortholog_disease ogd ;
-SELECT COUNT(DISTINCT ogd.target_id) AS "target_count" FROM ortholog_disease ogd ;
---- 
+SELECT COUNT(DISTINCT ogd.protein_id) AS "target_count" FROM ortholog_disease ogd ;
+
 SELECT
 	COUNT(DISTINCT ogd.id) AS "ortholog_disease_count",
 	og.species AS "species"


### PR DESCRIPTION
In line no 5 ogd.target_id is replaced with ogd.protein_id, as table ortholog_disease ogd doesn't have column ogd.target_id.